### PR TITLE
사용자 팔로잉 및 팔로우 개수

### DIFF
--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/model/Follow.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/model/Follow.java
@@ -39,5 +39,7 @@ public class Follow extends AbstractBaseTimeEntity {
 	public Follow(Member fromMember, Member toMember) {
 		this.fromMember = fromMember;
 		this.toMember = toMember;
+		fromMember.getFollowings().add(this);
+		toMember.getFollowers().add(this);
 	}
 }

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/repository/FollowCustomRepository.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/repository/FollowCustomRepository.java
@@ -1,0 +1,8 @@
+package com.youngxpepp.instagramcloneserver.domain.follow.repository;
+
+public interface FollowCustomRepository {
+
+	Long getFollowingCountByMemberNickname(String memberNickname);
+
+	Long getFollowerCountByMemberNickname(String memberNickname);
+}

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/repository/FollowCustomRepositoryImpl.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/repository/FollowCustomRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.youngxpepp.instagramcloneserver.domain.follow.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.youngxpepp.instagramcloneserver.domain.follow.model.QFollow;
+import com.youngxpepp.instagramcloneserver.domain.member.model.QMember;
+
+public class FollowCustomRepositoryImpl implements FollowCustomRepository {
+
+	@Autowired
+	private JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Long getFollowingCountByMemberNickname(String memberNickname) {
+		QFollow follow = QFollow.follow;
+		QMember member = QMember.member;
+
+		return jpaQueryFactory
+			.from(follow)
+			.innerJoin(follow.fromMember, member)
+			.where(member.nickname.eq(memberNickname))
+			.fetchCount();
+	}
+
+	@Override
+	public Long getFollowerCountByMemberNickname(String memberNickname) {
+		QFollow follow = QFollow.follow;
+		QMember member = QMember.member;
+
+		return jpaQueryFactory
+			.from(follow)
+			.innerJoin(follow.toMember, member)
+			.where(member.nickname.eq(memberNickname))
+			.fetchCount();
+	}
+}

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/repository/FollowRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.youngxpepp.instagramcloneserver.domain.follow.model.Follow;
 
-public interface FollowRepository extends JpaRepository<Follow, Long> {
+public interface FollowRepository extends JpaRepository<Follow, Long>, FollowCustomRepository {
 
 	Optional<Follow> findByFromMemberIdAndToMemberId(Long fromMemberId, Long toMemberId);
 }

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/controller/MemberController.java
@@ -1,0 +1,39 @@
+package com.youngxpepp.instagramcloneserver.domain.member.controller;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.youngxpepp.instagramcloneserver.domain.member.dto.MemberControllerDto;
+import com.youngxpepp.instagramcloneserver.domain.member.dto.MemberServiceDto;
+import com.youngxpepp.instagramcloneserver.domain.member.service.MemberService;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@AllArgsConstructor
+@Validated
+public class MemberController {
+
+	private MemberService memberService;
+
+	@GetMapping("/{memberNickname}")
+	public MemberControllerDto.GetMemberResponseDto getMember(
+		@PathVariable("memberNickname") @NotEmpty @NotNull String memberNickname) {
+
+		MemberServiceDto.GetMemberResponseDto serviceResponse = memberService.getMember(memberNickname);
+
+		return MemberControllerDto.GetMemberResponseDto.builder()
+			.memberNickname(serviceResponse.getMemberNickname())
+			.memberName(serviceResponse.getMemberName())
+			.memberEmail(serviceResponse.getMemberEmail())
+			.followerCount(serviceResponse.getFollowerCount())
+			.followingCount(serviceResponse.getFollowingCount())
+			.build();
+	}
+}

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/dto/MemberControllerDto.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/dto/MemberControllerDto.java
@@ -1,0 +1,34 @@
+package com.youngxpepp.instagramcloneserver.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberControllerDto {
+
+	@AllArgsConstructor
+	@Builder
+	@Getter
+	public static class GetMemberResponseDto {
+
+		@JsonProperty("member_nickname")
+		private String memberNickname;
+
+		@JsonProperty("member_name")
+		private String memberName;
+
+		@JsonProperty("member_email")
+		private String memberEmail;
+
+		@JsonProperty("follower_count")
+		private Integer followerCount;
+
+		@JsonProperty("following_count")
+		private Integer followingCount;
+	}
+}

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/dto/MemberControllerDto.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/dto/MemberControllerDto.java
@@ -26,9 +26,9 @@ public class MemberControllerDto {
 		private String memberEmail;
 
 		@JsonProperty("follower_count")
-		private Integer followerCount;
+		private Long followerCount;
 
 		@JsonProperty("following_count")
-		private Integer followingCount;
+		private Long followingCount;
 	}
 }

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/dto/MemberServiceDto.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/dto/MemberServiceDto.java
@@ -17,7 +17,7 @@ public class MemberServiceDto {
 		private String memberNickname;
 		private String memberName;
 		private String memberEmail;
-		private Integer followerCount;
-		private Integer followingCount;
+		private Long followerCount;
+		private Long followingCount;
 	}
 }

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/dto/MemberServiceDto.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/dto/MemberServiceDto.java
@@ -1,0 +1,23 @@
+package com.youngxpepp.instagramcloneserver.domain.member.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberServiceDto {
+
+	@AllArgsConstructor
+	@Builder
+	@Getter
+	public static class GetMemberResponseDto {
+
+		private String memberNickname;
+		private String memberName;
+		private String memberEmail;
+		private Integer followerCount;
+		private Integer followingCount;
+	}
+}

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/model/Member.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/model/Member.java
@@ -46,10 +46,10 @@ public class Member extends AbstractBaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private MemberRole role;
 
-	@OneToMany(mappedBy = "toMember", fetch = FetchType.EAGER)
+	@OneToMany(mappedBy = "toMember")
 	private List<Follow> followers = new ArrayList<>();
 
-	@OneToMany(mappedBy = "fromMember", fetch = FetchType.EAGER)
+	@OneToMany(mappedBy = "fromMember")
 	private List<Follow> followings = new ArrayList<>();
 
 	@Builder
@@ -59,13 +59,5 @@ public class Member extends AbstractBaseTimeEntity {
 		this.email = email;
 		this.password = password;
 		this.role = role;
-	}
-
-	public int getFollowersSize() {
-		return this.followers.size();
-	}
-
-	public int getFollowingsSize() {
-		return this.followings.size();
 	}
 }

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/model/Member.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/model/Member.java
@@ -2,10 +2,12 @@ package com.youngxpepp.instagramcloneserver.domain.member.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -44,10 +46,10 @@ public class Member extends AbstractBaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private MemberRole role;
 
-	@OneToMany(mappedBy = "toMember")
+	@OneToMany(mappedBy = "toMember", fetch = FetchType.EAGER)
 	private List<Follow> followers = new ArrayList<>();
 
-	@OneToMany(mappedBy = "fromMember")
+	@OneToMany(mappedBy = "fromMember", fetch = FetchType.EAGER)
 	private List<Follow> followings = new ArrayList<>();
 
 	@Builder
@@ -57,5 +59,13 @@ public class Member extends AbstractBaseTimeEntity {
 		this.email = email;
 		this.password = password;
 		this.role = role;
+	}
+
+	public int getFollowersSize() {
+		return this.followers.size();
+	}
+
+	public int getFollowingsSize() {
+		return this.followings.size();
 	}
 }

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/service/MemberService.java
@@ -4,10 +4,10 @@ import java.util.List;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.youngxpepp.instagramcloneserver.domain.follow.model.Follow;
+import com.youngxpepp.instagramcloneserver.domain.follow.repository.FollowRepository;
 import com.youngxpepp.instagramcloneserver.domain.member.dto.MemberServiceDto;
 import com.youngxpepp.instagramcloneserver.domain.member.model.Member;
 import com.youngxpepp.instagramcloneserver.domain.member.repository.MemberRepository;
@@ -19,21 +19,22 @@ import com.youngxpepp.instagramcloneserver.global.error.exception.BusinessExcept
 public class MemberService {
 
 	private MemberRepository memberRepository;
+	private FollowRepository followRepository;
 
 	@Transactional
 	public MemberServiceDto.GetMemberResponseDto getMember(String memberNickname) {
 		Member member = memberRepository.findByNickname(memberNickname)
 			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
 
-		member.getFollowersSize();
-		member.getFollowingsSize();
+		Long followerCount = followRepository.getFollowerCountByMemberNickname(memberNickname);
+		Long followingCount = followRepository.getFollowingCountByMemberNickname(memberNickname);
 
 		return MemberServiceDto.GetMemberResponseDto.builder()
 			.memberNickname(member.getNickname())
 			.memberName(member.getName())
 			.memberEmail(member.getEmail())
-			.followerCount(member.getFollowersSize())
-			.followingCount(member.getFollowingsSize())
+			.followerCount(followerCount)
+			.followingCount(followingCount)
 			.build();
 	}
 }

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/service/MemberService.java
@@ -1,0 +1,39 @@
+package com.youngxpepp.instagramcloneserver.domain.member.service;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.youngxpepp.instagramcloneserver.domain.follow.model.Follow;
+import com.youngxpepp.instagramcloneserver.domain.member.dto.MemberServiceDto;
+import com.youngxpepp.instagramcloneserver.domain.member.model.Member;
+import com.youngxpepp.instagramcloneserver.domain.member.repository.MemberRepository;
+import com.youngxpepp.instagramcloneserver.global.error.ErrorCode;
+import com.youngxpepp.instagramcloneserver.global.error.exception.BusinessException;
+
+@Service
+@AllArgsConstructor
+public class MemberService {
+
+	private MemberRepository memberRepository;
+
+	@Transactional
+	public MemberServiceDto.GetMemberResponseDto getMember(String memberNickname) {
+		Member member = memberRepository.findByNickname(memberNickname)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+
+		member.getFollowersSize();
+		member.getFollowingsSize();
+
+		return MemberServiceDto.GetMemberResponseDto.builder()
+			.memberNickname(member.getNickname())
+			.memberName(member.getName())
+			.memberEmail(member.getEmail())
+			.followerCount(member.getFollowersSize())
+			.followingCount(member.getFollowingsSize())
+			.build();
+	}
+}

--- a/src/main/java/com/youngxpepp/instagramcloneserver/global/config/QuerydslConfig.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/global/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.youngxpepp.instagramcloneserver.global.config;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(this.entityManager);
+	}
+}

--- a/src/test/java/com/youngxpepp/instagramcloneserver/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/youngxpepp/instagramcloneserver/domain/member/controller/MemberControllerTest.java
@@ -92,7 +92,7 @@ class MemberControllerTest extends IntegrationTest {
 			.andExpect(jsonPath("member_nickname").value(memberA.getNickname()))
 			.andExpect(jsonPath("member_name").value(memberA.getName()))
 			.andExpect(jsonPath("member_email").value(memberA.getEmail()))
-			.andExpect(jsonPath("follower_count").value(2))
-			.andExpect(jsonPath("following_count").value(2));
+			.andExpect(jsonPath("follower_count").value(2L))
+			.andExpect(jsonPath("following_count").value(2L));
 	}
 }

--- a/src/test/java/com/youngxpepp/instagramcloneserver/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/youngxpepp/instagramcloneserver/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,98 @@
+package com.youngxpepp.instagramcloneserver.domain.member.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.youngxpepp.instagramcloneserver.domain.follow.model.Follow;
+import com.youngxpepp.instagramcloneserver.domain.follow.repository.FollowRepository;
+import com.youngxpepp.instagramcloneserver.domain.member.model.Member;
+import com.youngxpepp.instagramcloneserver.domain.member.model.MemberRole;
+import com.youngxpepp.instagramcloneserver.domain.member.repository.MemberRepository;
+import com.youngxpepp.instagramcloneserver.test.IntegrationTest;
+
+class MemberControllerTest extends IntegrationTest {
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private FollowRepository followRepository;
+
+	@BeforeEach
+	void setUp() {
+	}
+
+	@AfterEach
+	void tearDown() {
+	}
+
+	@Test
+	public void Given_MemberABC서로팔로우_When_MemberA조회_Then_MemberA() throws Exception {
+
+		// given
+		Member memberA = Member.builder()
+			.email("a@gmail.com")
+			.name("a")
+			.nickname("a")
+			.password("a")
+			.role(MemberRole.MEMBER)
+			.build();
+		Member memberB = Member.builder()
+			.email("b@gmail.com")
+			.name("b")
+			.nickname("b")
+			.password("b")
+			.role(MemberRole.MEMBER)
+			.build();
+		Member memberC = Member.builder()
+			.email("c@gmail.com")
+			.name("c")
+			.nickname("c")
+			.password("c")
+			.role(MemberRole.MEMBER)
+			.build();
+		memberRepository.saveAll(Arrays.asList(memberA, memberB, memberC));
+
+		List<Follow> follows = new ArrayList<>();
+		follows.add(Follow.builder()
+			.fromMember(memberA)
+			.toMember(memberB)
+			.build());
+		follows.add(Follow.builder()
+			.fromMember(memberA)
+			.toMember(memberC)
+			.build());
+		follows.add(Follow.builder()
+			.fromMember(memberB)
+			.toMember(memberA)
+			.build());
+		follows.add(Follow.builder()
+			.fromMember(memberC)
+			.toMember(memberA)
+			.build());
+		followRepository.saveAll(follows);
+
+		// when
+		ResultActions resultActions =
+			mockMvc.perform(get("/api/v1/members/{memberNickname}", memberA.getNickname()));
+
+		// then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("member_nickname").value(memberA.getNickname()))
+			.andExpect(jsonPath("member_name").value(memberA.getName()))
+			.andExpect(jsonPath("member_email").value(memberA.getEmail()))
+			.andExpect(jsonPath("follower_count").value(2))
+			.andExpect(jsonPath("following_count").value(2));
+	}
+}

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -4,6 +4,5 @@
         "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
-<!--    <suppress files="UserController.java" checks=".*"/>-->
-<!--    <suppress files="UserService.java" checks=".*"/>-->
+    <suppress files="MemberControllerTest.java" checks="MethodName|AbbreviationAsWordInName"/>
 </suppressions>


### PR DESCRIPTION
- ~~Member에서 followers와 followings의 크기를 반환하는 멤버함수를 추가~~
> ~~size()에 접근할 때 lazy loading이 됩니다.~~

- 팔로잉 및 팔로워 수 쿼리 작성
> 많은 수의 팔로워를 갖고 있는 계정의 경우 메모리 사용량이 많아지기 때문에, count 쿼리를 통해 계산했습니다.

- MemberControllerDto와 MemberServiceDto 추가
> 사용자와 컨트롤러 간의 dto, 컨트롤러와 서비스 간의 dto 를 각자 선언합니다. 이를 통해 얻을 수 있는 이점은, 컨트롤러와 서비스의 결합도를 낮출 수 있으며 서비스 재사용성은 높일 수 있습니다.

- suppressions.xml 에 MemberControllerTest.java 추가
> 긴 메소드 이름과 맞지 않는 형식(snake_case)으로 인해 checkstyle 규칙 위반. 이를 해결하기 위해 suppression 추가.

- Member의 OneToMany Eager -> Lazy
> 테스트 작성 시에 Eager로 설정하고 복구 시켜놓지 않았습니다. N + 1 문제 발생 위험이 있으므로 Lazy로 바꿨습니다.