### PR TITLE
AuthenticationPrincipal 적용

### DIFF
--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/controller/FollowController.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotEmpty;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.youngxpepp.instagramcloneserver.domain.follow.dto.FollowRequestDto;
 import com.youngxpepp.instagramcloneserver.domain.follow.dto.UnfollowRequestDto;
 import com.youngxpepp.instagramcloneserver.domain.follow.service.FollowService;
+import com.youngxpepp.instagramcloneserver.domain.member.model.Member;
 import com.youngxpepp.instagramcloneserver.global.config.security.jwt.PostJwtAuthenticationToken;
 import com.youngxpepp.instagramcloneserver.global.error.exception.BusinessException;
 
@@ -33,21 +35,24 @@ public class FollowController {
 	private Validator validator;
 
 	@PostMapping
-	public void follow(@RequestBody @Valid FollowRequestDto dto) throws BusinessException {
-		PostJwtAuthenticationToken postJwtAuthenticationToken =
-			(PostJwtAuthenticationToken)SecurityContextHolder.getContext()
-				.getAuthentication();
-		followService.follow(postJwtAuthenticationToken.getMember(), dto);
+	public void follow(
+		@RequestBody @Valid FollowRequestDto dto,
+		@AuthenticationPrincipal Member principal
+	)
+		throws BusinessException {
+
+		followService.follow(principal, dto);
 	}
 
 	@DeleteMapping("/{memberNickname}")
-	public void unfollow(@PathVariable("memberNickname") String memberNickname) {
-		PostJwtAuthenticationToken postJwtAuthenticationToken =
-			(PostJwtAuthenticationToken)SecurityContextHolder.getContext()
-				.getAuthentication();
+	public void unfollow(
+		@PathVariable("memberNickname") String memberNickname,
+		@AuthenticationPrincipal Member principal
+	) {
+
 		UnfollowRequestDto dto = UnfollowRequestDto.builder()
 			.memberNickname(memberNickname)
 			.build();
-		followService.unfollow(postJwtAuthenticationToken.getMember(), dto);
+		followService.unfollow(principal, dto);
 	}
 }

--- a/src/main/java/com/youngxpepp/instagramcloneserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/global/config/security/SecurityConfig.java
@@ -86,8 +86,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 		http
 			.authorizeRequests()
-			.antMatchers("/api/v1/follows/**").hasRole("MEMBER")
-			.antMatchers("/api/v1/login").permitAll();
+			.antMatchers("/api/v1/follows/**").hasRole("MEMBER");
 
 		http
 			.addFilterBefore(this.jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/youngxpepp/instagramcloneserver/global/config/security/jwt/PostJwtAuthenticationToken.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/global/config/security/jwt/PostJwtAuthenticationToken.java
@@ -10,13 +10,12 @@ import com.youngxpepp.instagramcloneserver.domain.member.model.Member;
 
 public class PostJwtAuthenticationToken extends AbstractAuthenticationToken {
 
-	@Getter
-	private Member member;
+	private Member principal;
 
 	public PostJwtAuthenticationToken(List<SimpleGrantedAuthority> authorities, Member member) {
 		super(authorities);
 		super.setAuthenticated(true);
-		this.member = member;
+		this.principal = member;
 	}
 
 	@Override
@@ -26,6 +25,6 @@ public class PostJwtAuthenticationToken extends AbstractAuthenticationToken {
 
 	@Override
 	public Object getPrincipal() {
-		return null;
+		return this.principal;
 	}
 }


### PR DESCRIPTION
- PostJwtAuthenticationToken에 principal 추가
> @AuthenticationPrincipal은 Context의 Authentication의 getPrincipal을 호출한다.
> 따라서 PostJwtAuthenticationToken의 getPrincipal을 구현했다.

- @AuthenticationPrincipal 사용

- /api/v1/login authorizeRequests에서 제외
> AuthenticationToken에 authorities가 있는 경우에만 permit에 관한 설정을 할 수 있다.
> 하지만 로그인은 그 어떠한 인증 과정을 거치지 않으므로 authorizeRequests에서 제외했다.

- JwtAuthenticationFilter의 예외처리 버그 수정
> 해당 filter는 AbstractAuthenticationProcessingFilter를 상속하는데, doFilter를 그대로 쓰는 것으로 인해
> AuthenticationException이 제대로 처리되지 않았다. doFilter를 Override하여 직접 구현함으로써 버그 해결!
------
**@NJade 님 덕분에 Spring Security에 대해 한번 더 짚고 갈 수 있었습니다.
감사합니다👍**