### PR TITLE
JwtAuthenticationFilter 익명 사용자 처리

### DIFF
--- a/src/main/java/com/youngxpepp/instagramcloneserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/global/config/security/SecurityConfig.java
@@ -88,7 +88,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		http
 			.authorizeRequests()
 			.antMatchers("/api/v1/follows/**").hasRole("MEMBER")
-			.antMatchers("/api/v1/login").permitAll();
+			.antMatchers("/api/v1/login").anonymous();
 
 		http
 			.addFilterBefore(this.jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/youngxpepp/instagramcloneserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/global/config/security/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 		//        Jwt 인증 필터가 적용될 경로
 		patterns.add("/api/v1/follows/**");
+		patterns.add("/api/v1/login");
 
 		List<RequestMatcher> requestMatchers = patterns
 			.stream()
@@ -86,7 +87,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 		http
 			.authorizeRequests()
-			.antMatchers("/api/v1/follows/**").hasRole("MEMBER");
+			.antMatchers("/api/v1/follows/**").hasRole("MEMBER")
+			.antMatchers("/api/v1/login").permitAll();
 
 		http
 			.addFilterBefore(this.jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/youngxpepp/instagramcloneserver/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -19,7 +19,6 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import com.youngxpepp.instagramcloneserver.global.error.exception.BusinessException;
-import com.youngxpepp.instagramcloneserver.global.error.exception.NoAuthorizationException;
 
 public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
@@ -38,6 +37,13 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
 		HttpServletResponse response = (HttpServletResponse)res;
 
 		if (!requiresAuthentication(request, response)) {
+			chain.doFilter(request, response);
+
+			return;
+		}
+
+		String accessToken = request.getHeader("Authorization");
+		if (accessToken == null) {
 			chain.doFilter(request, response);
 
 			return;
@@ -66,10 +72,6 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
 	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
 		throws AuthenticationException, IOException, ServletException, JwtException {
 		String accessToken = request.getHeader("Authorization");
-
-		if (accessToken == null) {
-			throw new NoAuthorizationException("No authorization in header");
-		}
 
 		PreJwtAuthenticationToken preJwtAuthenticationToken = new PreJwtAuthenticationToken(accessToken);
 


### PR DESCRIPTION
- JwtAuthenticationFilter에서 익명 요청에 대해 예외 발생을 시키지 않게끔 수정
> 익명 요청인 경우에 예외 발생을 시키기 보다는, chain.doFilter()로 다음 필터로 요청을 넘겨버린다. 
> 이렇게 되면 authentication == null 이 되어서 익명 사용자 처리가 가능해진다.