### PR TITLE
Security의 AuthenticationException 처리

### DIFF
--- a/src/main/java/com/youngxpepp/instagramcloneserver/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/global/error/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -82,5 +83,11 @@ public class GlobalExceptionHandler {
 		DefaultErrorType errorType = new DefaultErrorType(ErrorCode.JWT_EXCEPTION);
 		return new ErrorResponse(errorType)
 			.responseEntity();
+	}
+
+	@ExceptionHandler(AuthenticationException.class)
+	public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException error) {
+		DefaultErrorType errorType = new DefaultErrorType(ErrorCode.HANDLE_ACCESS_DENIED);
+		return new ErrorResponse(errorType).responseEntity();
 	}
 }


### PR DESCRIPTION
- `SecurityConfig`의 `Autowired 주입`을  `생성자 주입`으로 변경
> DI가 되는 빈들을 `private final` 선언하고 `RequiredArgsConstructor`를 사용했다.

- `AuthenticationException`을 `GlobalExceptionHandler`로 넘기는 `AuthenticationEntryPoint`를 람다로 선언
> Spring Security 에서 기본적으로 처리되던 예외의 제어권을 Dispatcher Servlet 이후 단계에서 처리할 수 있게 한다.