### PR TITLE
Swagger 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     // https://mvnrepository.com/artifact/org.modelmapper/modelmapper
     implementation 'org.modelmapper:modelmapper:2.3.8'
 
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/follow/controller/FollowController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
 import com.youngxpepp.instagramcloneserver.domain.follow.dto.FollowRequestDto;
 import com.youngxpepp.instagramcloneserver.domain.follow.dto.UnfollowRequestDto;
@@ -37,17 +38,17 @@ public class FollowController {
 	@PostMapping
 	public void follow(
 		@RequestBody @Valid FollowRequestDto dto,
-		@AuthenticationPrincipal Member principal
+		@AuthenticationPrincipal @ApiIgnore Member principal
 	)
 		throws BusinessException {
 
 		followService.follow(principal, dto);
 	}
 
-	@DeleteMapping("/{memberNickname}")
+	@DeleteMapping("/{member_nickname}")
 	public void unfollow(
-		@PathVariable("memberNickname") String memberNickname,
-		@AuthenticationPrincipal Member principal
+		@PathVariable("member_nickname") String memberNickname,
+		@AuthenticationPrincipal @ApiIgnore Member principal
 	) {
 
 		UnfollowRequestDto dto = UnfollowRequestDto.builder()

--- a/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.youngxpepp.instagramcloneserver.domain.member.controller;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -22,9 +23,9 @@ public class MemberController {
 
 	private MemberService memberService;
 
-	@GetMapping("/{memberNickname}")
+	@GetMapping("/{nickname}")
 	public MemberControllerDto.GetMemberResponseDto getMember(
-		@PathVariable("memberNickname") @NotEmpty @NotNull String memberNickname) {
+		@PathVariable("nickname") @NotBlank String memberNickname) {
 
 		MemberServiceDto.GetMemberResponseDto serviceResponse = memberService.getMember(memberNickname);
 

--- a/src/main/java/com/youngxpepp/instagramcloneserver/global/config/SwaggerConfig.java
+++ b/src/main/java/com/youngxpepp/instagramcloneserver/global/config/SwaggerConfig.java
@@ -1,0 +1,42 @@
+package com.youngxpepp.instagramcloneserver.global.config;
+
+import java.util.Arrays;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.builders.RequestParameterBuilder;
+import springfox.documentation.service.ParameterType;
+import springfox.documentation.service.RequestParameter;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean("swaggerEnabled")
+	public Boolean getSwaggerEnabled(Environment environment) {
+		return environment.acceptsProfiles(Profiles.of("dev", "local"));
+	}
+
+	@Bean
+	public Docket getDocket(@Qualifier("swaggerEnabled") Boolean swaggerEnabled) {
+		RequestParameter authorization = new RequestParameterBuilder()
+			.in(ParameterType.HEADER)
+			.name("Authorization")
+			.required(false)
+			.build();
+
+		return new Docket(DocumentationType.SWAGGER_2)
+			.enable(swaggerEnabled)
+			.globalRequestParameters(Arrays.asList(authorization))
+			.select()
+			.apis(RequestHandlerSelectors.any())
+			.paths(PathSelectors.ant("/api/v1/**"))
+			.build();
+	}
+}

--- a/src/test/java/com/youngxpepp/instagramcloneserver/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/youngxpepp/instagramcloneserver/domain/member/controller/MemberControllerTest.java
@@ -84,7 +84,7 @@ class MemberControllerTest extends IntegrationTest {
 
 		// when
 		ResultActions resultActions =
-			mockMvc.perform(get("/api/v1/members/{memberNickname}", memberA.getNickname()));
+			mockMvc.perform(get("/api/v1/members/{nickname}", memberA.getNickname()));
 
 		// then
 		resultActions


### PR DESCRIPTION
- Swagger 의존성 추가 및 설정
> profile이 dev와 local에서만 Swagger가 동작하도록 한다. Swagger URL은 다음과 같은 형식이다. 
 http://localhost:8080/swagger-ui/index.html#/ 
- 컨트롤러 메소드에 Member principal 에 관한 내용이 의도치 않게 Swagger에 표시된다. 이를 어노테이션 ApiIgnore 를 통해서 해결했다.
- GET /api/v1/members/{memberNickname} -> GET /api/v1/members/{nickname} 
> 직관적인 이름 채택